### PR TITLE
rename msgTypePrefix to fit grants team

### DIFF
--- a/app/config/messaging.js
+++ b/app/config/messaging.js
@@ -19,6 +19,17 @@ const messageConfigSchema = Joi.object({
     type: Joi.string(),
     ...sharedConfigSchema
   },
+  applicationRequestQueue: {
+    address: Joi.string().default('applicationRequestQueue'),
+    type: Joi.string(),
+    ...sharedConfigSchema
+  },
+  applicationResponseQueue: {
+    address: Joi.string().default('applicationResponseQueue'),
+    type: Joi.string(),
+    ...sharedConfigSchema
+  },
+  fetchApplicationRequestMsgType: Joi.string(),
   eligibilityAnswersMsgType: Joi.string(),
   projectDetailsMsgType: Joi.string(),
   contactDetailsMsgType: Joi.string(),
@@ -46,6 +57,17 @@ const config = {
     type: 'queue',
     ...sharedConfig
   },
+  applicationRequestQueue: {
+    address: process.env.APPLICATIONREQUEST_QUEUE_ADDRESS + '-' + process.env.ENVIRONMENT_CODE,
+    type: 'queue',
+    ...sharedConfig
+  },
+  applicationResponseQueue: {
+    address: process.env.APPLICATIONRESPONSE_QUEUE_ADDRESS  + '-' + process.env.ENVIRONMENT_CODE,
+    type: 'queue',
+    ...sharedConfig
+  },
+  fetchApplicationRequestMsgType: `${msgTypePrefix}.fetch.app.request`,
   eligibilityAnswersMsgType: `${msgTypePrefix}.av.eligibility.details`,
   projectDetailsMsgType: `${msgTypePrefix}.av.project.details`,
   contactDetailsMsgType: `${msgTypePrefix}.av.contact.details`,

--- a/app/config/server.js
+++ b/app/config/server.js
@@ -3,7 +3,7 @@ const urlPrefix = '/slurry-infrastructure'
 const startPageUrl = '/start'
 const serviceEndDate = '2024/07/12'
 const serviceEndTime = '23:59:59'
-const msgTypePrefix = 'uk.gov.ffc.ahwr'
+const msgTypePrefix = 'uk.gov.ffc.grants'
 
 require('dotenv').config()
 

--- a/app/config/server.js
+++ b/app/config/server.js
@@ -3,17 +3,8 @@ const urlPrefix = '/slurry-infrastructure'
 const startPageUrl = '/start'
 const serviceEndDate = '2024/07/12'
 const serviceEndTime = '23:59:59'
-const msgTypePrefix = 'uk.gov.ffc.grants'
 
 require('dotenv').config()
-
-const sharedConfigSchema = {
-  appInsights: Joi.object(),
-  host: Joi.string().default('localhost'),
-  password: Joi.string(),
-  username: Joi.string(),
-  useCredentialChain: Joi.bool().default(false)
-}
 
 // Define config schema
 const schema = Joi.object({
@@ -37,26 +28,7 @@ const schema = Joi.object({
     key: Joi.string(),
     role: Joi.string().default('ffc-grants-slurry')
   },
-  applicationRequestQueue: {
-    address: Joi.string().default('applicationRequestQueue'),
-    type: Joi.string(),
-    ...sharedConfigSchema
-  },
-  applicationResponseQueue: {
-    address: Joi.string().default('applicationResponseQueue'),
-    type: Joi.string(),
-    ...sharedConfigSchema
-  },
-  fetchApplicationRequestMsgType: Joi.string(),
 })
-
-const sharedConfig = {
-  appInsights: require('applicationinsights'),
-  host: process.env.SERVICE_BUS_HOST,
-  password: process.env.SERVICE_BUS_PASSWORD,
-  username: process.env.SERVICE_BUS_USER,
-  useCredentialChain: process.env.NODE_ENV === 'production'
-}
 
 // Build config
 const config = {
@@ -80,17 +52,6 @@ const config = {
     key: process.env.APPINSIGHTS_INSTRUMENTATIONKEY,
     role: process.env.APPINSIGHTS_CLOUDROLE
   },
-  applicationRequestQueue: {
-    address: process.env.APPLICATIONREQUEST_QUEUE_ADDRESS + '-' + process.env.ENVIRONMENT_CODE,
-    type: 'queue',
-    ...sharedConfig
-  },
-  applicationResponseQueue: {
-    address: process.env.APPLICATIONRESPONSE_QUEUE_ADDRESS  + '-' + process.env.ENVIRONMENT_CODE,
-    type: 'queue',
-    ...sharedConfig
-  },
-  fetchApplicationRequestMsgType: `${msgTypePrefix}.fetch.app.request`,
 }
 
 // Validate config

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ffc-grants-slurry-web",
-  "version": "1.17.7",
+  "version": "1.17.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ffc-grants-slurry-web",
-      "version": "1.17.7",
+      "version": "1.17.8",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@defra/hapi-gapi": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ffc-grants-slurry-web",
-  "version": "1.17.2",
+  "version": "1.17.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ffc-grants-slurry-web",
-      "version": "1.17.2",
+      "version": "1.17.7",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@defra/hapi-gapi": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-grants-slurry-web",
-  "version": "1.17.7",
+  "version": "1.17.8",
   "description": "Web frontend for FTF Slurry Infrastructure scheme",
   "homepage": "https://github.com/DEFRA/ffc-grants-slurry-web",
   "main": "app/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-grants-slurry-web",
-  "version": "1.17.6",
+  "version": "1.17.7",
   "description": "Web frontend for FTF Slurry Infrastructure scheme",
   "homepage": "https://github.com/DEFRA/ffc-grants-slurry-web",
   "main": "app/index.js",


### PR DESCRIPTION
msgTypePrefix was copied from ahwr, so in server.js it was stated as 'uk.gov.ffc.ahwr'. This has been renamed now